### PR TITLE
fix: calling scroll methods without window context

### DIFF
--- a/src/patch/window/scroll-by.ts
+++ b/src/patch/window/scroll-by.ts
@@ -4,7 +4,7 @@ import {handleScrollMethod} from "../shared";
  * Patches the 'scrollBy' method on the Window prototype
  */
 export function patchWindowScrollBy(): void {
-	window.scrollBy = function(this: Window, optionsOrX?: number | ScrollToOptions, y?: number): void {
-		handleScrollMethod(this, "scrollBy", optionsOrX, y);
+	window.scrollBy = function(this: Window | undefined, optionsOrX?: number | ScrollToOptions, y?: number): void {
+		handleScrollMethod(this ?? window, "scrollBy", optionsOrX, y);
 	};
 }

--- a/src/patch/window/scroll-to.ts
+++ b/src/patch/window/scroll-to.ts
@@ -4,7 +4,7 @@ import {handleScrollMethod} from "../shared";
  * Patches the 'scrollTo' method on the Window prototype
  */
 export function patchWindowScrollTo(): void {
-	window.scrollTo = function(this: Window, optionsOrX?: number | ScrollToOptions, y?: number): void {
-		handleScrollMethod(this, "scrollTo", optionsOrX, y);
+	window.scrollTo = function(this: Window | undefined, optionsOrX?: number | ScrollToOptions, y?: number): void {
+		handleScrollMethod(this ?? window, "scrollTo", optionsOrX, y);
 	};
 }

--- a/src/patch/window/scroll.ts
+++ b/src/patch/window/scroll.ts
@@ -4,7 +4,7 @@ import {handleScrollMethod} from "../shared";
  * Patches the 'scroll' method on the Window prototype
  */
 export function patchWindowScroll(): void {
-	window.scroll = function(this: Window, optionsOrX?: number | ScrollToOptions, y?: number): void {
-		handleScrollMethod(this, "scroll", optionsOrX, y);
+	window.scroll = function(this: Window | undefined, optionsOrX?: number | ScrollToOptions, y?: number): void {
+		handleScrollMethod(this ?? window, "scroll", optionsOrX, y);
 	};
 }


### PR DESCRIPTION
When calling patched scrolling methods without window context `scrollTo(0, 0)` `getScrollBehavior` throws an error because `inputTarget` is `undefined`.

So the solution is to provide default `window` context when calling patched methods.