### PR TITLE
remove $ from npm and yarn install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ This polyfill also implements the extensions to the Element interface in the [CS
 ### NPM
 
 ```
-$ npm install scroll-behavior-polyfill
+npm install scroll-behavior-polyfill`
 ```
 
 ### Yarn
 
 ```
-$ yarn add scroll-behavior-polyfill
+yarn add scroll-behavior-polyfill
 ```
 
 <!-- SHADOW_SECTION_INSTALL_END -->


### PR DESCRIPTION
remove $ from the npm and yarn install commands to prevent error when pasting it into console after using the "copy" button on the code block (code gets copied with the $, which returns a `command not found: $` error in the console)

![image](https://user-images.githubusercontent.com/42058106/133389760-36a22c87-975f-4347-88c8-bf19d964999b.png)
